### PR TITLE
Benchmark chacha

### DIFF
--- a/random-benchmarks/random-benchmarks.cabal
+++ b/random-benchmarks/random-benchmarks.cabal
@@ -36,9 +36,11 @@ benchmark random
   hs-source-dirs: bench
   ghc-options: -Wall -O2 -threaded -rtsopts -with-rtsopts=-N
   build-depends: base
+               , bytestring
                , criterion
                , random-benchmarks
                , massiv >=0.3.4
+               , memory
                , scheduler
 
                , random
@@ -51,6 +53,7 @@ benchmark random
                , Xorshift128Plus
                , pcgen
                , splitmix
+               , cryptonite
 
                , mwc-random
                , sfmt


### PR DESCRIPTION
Not really meant for merging, just an experiment.

This is to get data for an informed discussion about whether `random` should default to a CPRNG (I think not), raised e.g. here: https://www.reddit.com/r/haskell/comments/f5clfy/proposal_to_improve_the_random_library/fhzze9t/

Results:

<pre>
random-benchmarks> benchmarks
Running 1 benchmarks...        
Benchmark random: RUNNING...   
benchmarking IO/Word64/Seq/mwc-random
time                 14.47 ms   (12.40 ms .. 16.11 ms)
                     0.949 R²   (0.912 R² .. 0.985 R²)
mean                 13.10 ms   (12.51 ms .. 13.61 ms)
std dev              1.409 ms   (1.039 ms .. 2.079 ms)
variance introduced by outliers: 56% (severely inflated)
                               
benchmarking IO/Word64/Seq/sfmt
time                 10.48 ms   (7.407 ms .. 16.07 ms)
                     0.567 R²   (0.369 R² .. 0.813 R²)
mean                 12.15 ms   (10.73 ms .. 14.17 ms)
std dev              4.267 ms   (3.445 ms .. 6.275 ms)
variance introduced by outliers: 96% (severely inflated)
                               
benchmarking IO/Word64/Seq/pcg-random
time                 11.71 ms   (8.563 ms .. 15.30 ms)
                     0.784 R²   (0.732 R² .. 0.958 R²)
mean                 8.856 ms   (8.252 ms .. 10.16 ms)
std dev              2.321 ms   (1.289 ms .. 4.524 ms)
variance introduced by outliers: 90% (severely inflated)
                               
benchmarking IO/Word64/Seq/pcg-random (fast)
time                 12.03 ms   (10.09 ms .. 14.55 ms)
                     0.883 R²   (0.789 R² .. 0.971 R²)
mean                 14.77 ms   (13.85 ms .. 15.51 ms)
std dev              2.080 ms   (1.555 ms .. 2.883 ms)
variance introduced by outliers: 67% (severely inflated)
                               
benchmarking IO/Word64/Seq/mersenne-random
time                 6.631 ms   (5.292 ms .. 7.905 ms)
                     0.809 R²   (0.684 R² .. 0.888 R²)
mean                 10.37 ms   (9.527 ms .. 11.36 ms)
std dev              2.514 ms   (2.102 ms .. 3.129 ms)
variance introduced by outliers: 90% (severely inflated)
                  
<strong>             
benchmarking IO/Word64/Seq/chacha
time                 930.6 ms   (804.2 ms .. 1.035 s)
                     0.998 R²   (0.992 R² .. 1.000 R²)
mean                 1.040 s    (989.5 ms .. 1.136 s)
std dev              92.90 ms   (3.736 ms .. 112.4 ms)
variance introduced by outliers: 22% (moderately inflated)
</strong>
</pre>